### PR TITLE
Way to disable select form extension 

### DIFF
--- a/Form/Extension/BootstrapSelectExtension.php
+++ b/Form/Extension/BootstrapSelectExtension.php
@@ -13,7 +13,7 @@ class BootstrapSelectExtension extends AbstractTypeExtension
 {
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if (false === $options['expanded']) {
+        if (false === $options['expanded'] && !array_key_exists('class', $options['attr'])) {
             $view->vars['attr'] = array_merge($view->vars['attr'], array(
                 'class' => 'selectpicker'
             ));


### PR DESCRIPTION
Use form extension for expanded choice fields unless class is explicitly set.